### PR TITLE
Update to Remove Auto-Destroy for All Except Some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-10-06
+
+- update for 7DTD 1.1 (b14)
+- update to remove auto-destroy for all except some
+
 ## [1.0.0] - 2024-07-20
 
 - initial release

--- a/Config/loot.xml
+++ b/Config/loot.xml
@@ -1,3 +1,14 @@
 <config>
-    <removeattribute xpath="/lootcontainers/lootcontainer[@name='birdNest' or @name='junk' or @name='trashShelves' or @name='shamwayShelves' or @name='popnpillsShelves' or @name='mopowerShelves' or @name='weaponsBagLarge' or @name='weaponsBagSmall' or @name='militaryShelves' or @name='clothesRacks' or @name='armorRack' or @name='gunRack' or @name='bookPile' or @name='singleBooks' or @name='crackabookShelves' or @name='coolerMedical' or @name='medicalPillCase' or @name='medicalPileSmall' or @name='medicalPileMedium' or @name='medicalPileLarge' or @name='liquorPileSmall' or @name='liquorPileMed' or @name='liquorPileLarge' or @name='chemPileSmall' or @name='chemPileMed' or @name='chemPileLarge' or @name='foodPileSmall' or @name='foodPileMed' or @name='foodPileLarge' or @name='ammoPileSmall' or @name='ammoPileMed' or @name='ammoPileLarge']/@destroy_on_close" />
+    <!-- Remove destroy_on_close logic on all containers except for:
+        - @name='playerBackpack': 1
+        - @name='buriedTreasure': 1
+        - @name='airDrop': 1
+        - @name='questRewardSkillMagazines': 1
+        - contains(@name, 'infested'): 5
+        - contains(@name, 'twitch'): 66
+
+        * counts are accurate as of 7DTD 1.1 (b14): 161 w/ destroy_on_close - 75 to exclude = 86 loot containers will no longer trigger destroy_on_close *
+    -->
+
+    <removeattribute xpath="/lootcontainers/lootcontainer[not (@name='playerBackpack') and not (@name='buriedTreasure') and not (@name='airDrop') and not (@name='questRewardSkillMagazines') and not (contains(@name, 'infested')) and not (contains(@name, 'twitch'))]/@destroy_on_close" />
 </config>

--- a/Config/loot.xml
+++ b/Config/loot.xml
@@ -1,7 +1,8 @@
 <config>
     <!-- Remove destroy_on_close logic on all containers except for:
         - @name='playerBackpack': 1
-        - @name='buriedTreasure': 1
+        - contains(@name, 'buried'): 1  [including as 'contains' for compatibility with some other mods]
+        - contains(@name, 'Buried'): 0  [including for compatibility with some other mods]
         - @name='airDrop': 1
         - @name='questRewardSkillMagazines': 1
         - contains(@name, 'infested'): 5
@@ -10,5 +11,5 @@
         * counts are accurate as of 7DTD 1.1 (b14): 161 w/ destroy_on_close - 75 to exclude = 86 loot containers will no longer trigger destroy_on_close *
     -->
 
-    <removeattribute xpath="/lootcontainers/lootcontainer[not (@name='playerBackpack') and not (@name='buriedTreasure') and not (@name='airDrop') and not (@name='questRewardSkillMagazines') and not (contains(@name, 'infested')) and not (contains(@name, 'twitch'))]/@destroy_on_close" />
+    <removeattribute xpath="/lootcontainers/lootcontainer[not (@name='playerBackpack') and not (contains(@name, 'buried')) and not (contains(@name, 'Buried')) and not (@name='airDrop') and not (@name='questRewardSkillMagazines') and not (contains(@name, 'infested')) and not (contains(@name, 'twitch'))]/@destroy_on_close" />
 </config>

--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -2,7 +2,7 @@
 <xml>
     <Name value="kanaverum-renewable-loot" />
     <DisplayName value="Renewable Loot" />
-    <Version value="1.0.0" />
+    <Version value="1.1.0" />
     <Description value="Keep many containers from breaking when they are looted." />
     <Author value="Jonathan Robertson (Kanaverum)" />
     <Website value="https://github.com/jonathan-robertson/renewable-loot" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Renewable Loot
 
-[![🧪 Tested On](https://img.shields.io/badge/🧪%20Tested%20On-1.0%20b327-blue.svg)](https://7daystodie.com/) [![📦 Automated Release](https://github.com/jonathan-robertson/renewable-loot/actions/workflows/release.yml/badge.svg)](https://github.com/jonathan-robertson/renewable-loot/actions/workflows/release.yml)
+[![🧪 Tested On 7DTD 1.1 (b14)](https://img.shields.io/badge/🧪%20Tested%20On-7DTD%201.1%20(b14)-blue.svg)](https://7daystodie.com/) [![📦 Automated Release](https://github.com/jonathan-robertson/renewable-loot/actions/workflows/release.yml/badge.svg)](https://github.com/jonathan-robertson/renewable-loot/actions/workflows/release.yml)
 
 - [Renewable Loot](#renewable-loot)
   - [Summary](#summary)


### PR DESCRIPTION
## Remove `destroy_on_close` logic on all containers except for:
- `@name='playerBackpack'`: 1
- `contains(@name, 'buried')`: 1  [including as 'contains' for compatibility with some other mods]
- `contains(@name, 'Buried')`: 0  [including for compatibility with some other mods]
- `@name='airDrop'`: 1
- `@name='questRewardSkillMagazines'`: 1
- `contains(@name, 'infested')`: 5
- `contains(@name, 'twitch')`: 66
> *counts are accurate as of 7DTD 1.1 (b14)*: 161 w/ `destroy_on_close` - 75 to exclude = 86 loot containers
> ... *will no longer trigger destroy_on_close*